### PR TITLE
Pass api_key param in GPT4V constructor explicitly

### DIFF
--- a/experiments/gpt4v-classification/app.py
+++ b/experiments/gpt4v-classification/app.py
@@ -1,5 +1,6 @@
 from autodistill_gpt_4v import GPT4V
 from autodistill.detection import CaptionOntology
+import os
 
 base_model = GPT4V(
     ontology=CaptionOntology(
@@ -7,7 +8,8 @@ base_model = GPT4V(
             "salmon": "salmon",
             "carp": "carp"
         }
-    )
+    ),
+    api_key=os.environ["OPENAI_API_KEY"]
 )
 
 result = base_model.predict("fish.jpg", base_model.ontology.prompts())

--- a/experiments/gpt4v-grounding-dino-detection/app.py
+++ b/experiments/gpt4v-grounding-dino-detection/app.py
@@ -5,6 +5,7 @@ from autodistill.utils import plot
 
 from autodistill.core.custom_detection_model import CustomDetectionModel
 import cv2
+import os
 
 classes = ["mercedes", "toyota"]
 
@@ -14,7 +15,8 @@ DINOGPT = CustomDetectionModel(
         CaptionOntology({"car": "car"})
     ),
     classification_model=GPT4V(
-        CaptionOntology({k: k for k in classes})
+        CaptionOntology({k: k for k in classes}),
+        api_key=os.environ["OPENAI_API_KEY"]
     )
 )
 

--- a/experiments/gpt4v-vs-clip/app.py
+++ b/experiments/gpt4v-vs-clip/app.py
@@ -1,6 +1,7 @@
 from autodistill_gpt_4v import GPT4V
 from autodistill.detection import CaptionOntology
 from autodistill_clip import CLIP
+import os
 
 prompts = ["chicago deep dish pizza", "pizza"]
 
@@ -16,7 +17,7 @@ class_result = prompts[clip_result.class_id[0]]
 
 print("CLIP result: ", class_result)
 
-gpt_4v_model = GPT4V(ontology=ontology)
+gpt_4v_model = GPT4V(ontology=ontology, api_key=os.environ["OPENAI_API_KEY"])
 
 gpt_result = gpt_4v_model.predict("deep-dish.jpg", gpt_4v_model.ontology.prompts())
 

--- a/experiments/gpt4v-vs-clip/requirements.txt
+++ b/experiments/gpt4v-vs-clip/requirements.txt
@@ -1,3 +1,3 @@
-autodistill_gpt4v
+autodistill_gpt-4v
 autodistill_clip
 autodistill


### PR DESCRIPTION
# Description

According to #3 OpenAI library cannot read api_key


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Additionally fixed one invalid requirement declaration

## How has this change been tested, please provide a testcase or example of how you tested the change?

Just run those scripts

## Any specific deployment considerations

According to[ official docs](https://platform.openai.com/docs/quickstart/step-2-setup-your-api-key) it should work out of the box but maybe this is some temporary bug on their side.

